### PR TITLE
remove loading state

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Linux requires Bevy's [Linux dependencies](https://github.com/bevyengine/bevy/bl
 Levels should be placed within `assets/levels`.
 
 To load a specific level use the `--level` argument to provide the desired asset path.
-To skip normal startup and start the level immediately, use `--initial-state loading`. For example:
+To skip normal startup and start the level immediately, use `--initial-state game`. For example:
 ```sh
-$ cargo run -- --level levels/test.ron --initial-state loading
+$ cargo run -- --level levels/test.ron --initial-state game
 ```

--- a/src/bird/mod.rs
+++ b/src/bird/mod.rs
@@ -16,7 +16,7 @@ impl Plugin for BirdPlugin {
     fn build(&self, app: &mut App) {
         app.init_asset::<BirdAsset>();
         app.init_asset_loader::<RonAssetLoader<BirdAsset>>();
-        app.add_systems(OnEnter(GameState::Loading), setup_sys);
+        app.add_systems(OnEnter(GameState::Game), setup_sys);
         app.add_systems(FixedUpdate, setup_spawner_sys.run_if(in_state(GameState::Game)));
         app.add_systems(FixedUpdate, (
             bird_spawn_sys,
@@ -81,7 +81,9 @@ fn setup_sys(
     mut cmd: Commands,
     asset_server: Res<AssetServer>,
 ) {
-    cmd.spawn((
+    // This is a bit of a hack to make sure only 1 BirdTweetText ever exists.
+    // Otherwise another gets added each time we enter game state which causes a panic elsewhere.
+    once!(cmd.spawn((
         BirdTweetText,
         Text::new("howdy!".to_string()), // initial greeting before any birds show up
         TextFont {
@@ -96,5 +98,5 @@ fn setup_sys(
             right: Val::Px(5.),
             ..default()
         },
-    ));
+    )));
 }

--- a/src/level.rs
+++ b/src/level.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use bevy::{prelude::*, text::cosmic_text::Command, utils::HashMap};
+use bevy::prelude::*;
 use serde::Deserialize;
 
 use crate::{util::ron_asset_loader::RonAssetLoader, GameState};
@@ -24,14 +24,17 @@ impl Plugin for LevelPlugin {
                 default_level_path: self.default_level.clone(),
                 ..default()
             })
-            .add_systems(FixedUpdate, load_level_sys.run_if(in_state(GameState::Loading)));
+            .add_systems(OnEnter(GameState::Game), load_level_sys);
     }
 }
 
 /// State related to current level
 #[derive(Debug, Resource, Default)]
 pub struct Level {
-    /// Current level, will be loaded by [load_level_sys] when [GameState::Loading].
+    /// Current level, loading of which will be triggered by [load_level_sys]
+    /// when entering [GameState::Game].
+    ///
+    /// TODO: would make sense to differentiate current level from next level.
     pub level_handle: Handle<LevelAsset>,
     /// Fallback level if none is given.
     default_level_path: PathBuf,
@@ -56,18 +59,7 @@ pub struct LevelBird {
 /// Wait for current level asset to load then setup game and transition to [GameState::Game] when ready.
 fn load_level_sys(
     mut level: ResMut<Level>,
-    mut game_state: ResMut<NextState<GameState>>,
     asset_server: Res<AssetServer>,
-    level_assets: Res<Assets<LevelAsset>>,
 ) {
-    if asset_server.is_managed(level.level_handle.id()) {
-        if  let Some(level_asset) = level_assets.get(&level.level_handle) {
-            info!("Level loaded: ${:?}", level_asset);
-            game_state.set(GameState::Game);
-        }
-    }
-    else {
-        level.level_handle = asset_server.load(level.default_level_path.clone());
-    }
-
+    level.level_handle = asset_server.load(level.default_level_path.clone());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,6 @@ pub(crate) enum GameState {
     #[default]
     Menu,
     Splash,
-    Loading,
 }
 
 // a label component to tell us which things are loaded in the Game GameState

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -224,7 +224,7 @@ fn menu_button_action_sys(
                     info!("menu state: main menu")
                 }
                 MenuButtonAction::NewGame => {
-                    game_state.set(GameState::Loading);
+                    game_state.set(GameState::Game);
                     menu_state.set(MenuState::Disabled);
                     info!("menu state: disabled and game state: game!")
                 }


### PR DESCRIPTION
while a loading state my be desired in future, the current implementation introduced unnecessary complexity that could be better handled with other methods. 

now, moving to game state will trigger loading of the level and game systems have been updated to handle the case that no level exists. this sounds like extra work, but these systems previously had to trust that the level had been loaded when unwrapping the level asset data.