### PR TITLE
generalise asset management within AssetManagerPlugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,7 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "js-sys",
+ "notify-debouncer-full",
  "parking_lot",
  "ron",
  "serde",
@@ -2023,6 +2024,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-id"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bc904b9bbefcadbd8e3a9fb0d464a9b979de6324c03b3c663e8994f46a5be36"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2116,6 +2138,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2204,7 +2235,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ed3920aa2e2a5b02fb67182e269b7c988ffbba86e1278bb9f9bbe1815e3ae1"
 dependencies = [
  "core-foundation 0.10.0",
- "inotify",
+ "inotify 0.11.0",
  "io-kit-sys",
  "js-sys",
  "libc",
@@ -2458,6 +2489,17 @@ checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
 
 [[package]]
 name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
@@ -2474,6 +2516,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2564,6 +2615,26 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "kqueue"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
 
 [[package]]
 name = "ktx2"
@@ -2736,6 +2807,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "naga"
 version = "23.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2857,6 +2940,47 @@ name = "nonmax"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.9.0",
+ "filetime",
+ "fsevent-sys",
+ "inotify 0.10.2",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcf855483228259b2353f89e99df35fc639b2b2510d1166e4858e3f67ec1afb"
+dependencies = [
+ "file-id",
+ "log",
+ "notify",
+ "notify-types",
+ "walkdir",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "ntapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-bevy = "0.15.3"
+bevy = { version = "0.15.3", features = ["file_watcher"] }
 clap = { version = "4.5.32", features = ["derive"] }
 rand = "0.9.0"
 ron = "0.8.1"

--- a/src/bird/mod.rs
+++ b/src/bird/mod.rs
@@ -8,14 +8,18 @@ use spawner::*;
 use bevy::prelude::*;
 use rand::Rng;
 
-use crate::{level::Level, physics::{ColliderContactEvent, Velocity}, util::ron_asset_loader::RonAssetLoader, GameState};
+use crate::{
+    level::Level,
+    physics::{ColliderContactEvent, Velocity},
+    util::AssetManagerPlugin,
+    GameState
+};
 
 pub struct BirdPlugin;
 
 impl Plugin for BirdPlugin {
     fn build(&self, app: &mut App) {
-        app.init_asset::<BirdAsset>();
-        app.init_asset_loader::<RonAssetLoader<BirdAsset>>();
+        app.add_plugins(AssetManagerPlugin::<BirdAsset>::default());
         app.add_systems(OnEnter(GameState::Game), setup_sys);
         app.add_systems(FixedUpdate, setup_spawner_sys.run_if(in_state(GameState::Game)));
         app.add_systems(FixedUpdate, (

--- a/src/bird/spawner.rs
+++ b/src/bird/spawner.rs
@@ -1,11 +1,11 @@
-use std::f32::consts::PI;
-
+use super::asset::BirdAsset;
+use crate::{
+    level::{Level, LevelAsset},
+    util::AssetHandle,
+};
 use bevy::{prelude::*, utils::HashMap};
 use rand::Rng;
-
-use crate::level::{Level, LevelAsset};
-
-use super::asset::BirdAssetHandle;
+use std::f32::consts::PI;
 
 #[derive(Component)]
 pub struct BirdSpawner {
@@ -38,19 +38,22 @@ pub(super) fn bird_spawn_sys(
                 last_entity_spawn_time.insert(entity, time_now);
 
                 // Choose a bird from the level at random based based on its `spawn_probability`
-                let mut total_probability= 0.;
+                let mut total_probability = 0.;
                 let mut cumulative_probability = vec![];
                 for bird in level_asset.birds.iter() {
                     total_probability += bird.spawn_probability;
                     cumulative_probability.push(total_probability);
                 }
-                let random_p = rng.random_range(0. .. total_probability);
-                let random_index = cumulative_probability.iter().position(|p| &random_p <= p).unwrap_or(0);
+                let random_p = rng.random_range(0. ..total_probability);
+                let random_index = cumulative_probability
+                    .iter()
+                    .position(|p| &random_p <= p)
+                    .unwrap_or(0);
                 let random_bird = &level_asset.birds[random_index];
 
                 cmd.spawn((
-                    BirdAssetHandle(asset_server.load(random_bird.asset.as_str())),
-                    spawner_tf.clone()
+                    AssetHandle::<BirdAsset>(asset_server.load(random_bird.asset.as_str())),
+                    spawner_tf.clone(),
                 ));
             }
         }
@@ -77,9 +80,9 @@ pub(super) fn setup_spawner_sys(
                     let x = ((window_width - bird_padding) / (level.spawner_qty - 1) as f32) * i as f32;
 
                     let mut transform = Transform::from_xyz(
-                        x - (window_width - bird_padding) * 0.5 ,
+                        x - (window_width - bird_padding) * 0.5,
                         (window_height * 0.5) + 100.,
-                        50.
+                        50.,
                     );
                     transform.rotate_local_x(PI);
                     cmd.spawn((
@@ -90,10 +93,9 @@ pub(super) fn setup_spawner_sys(
                         transform,
                     ));
                 }
-            },
+            }
             // todo: handle despawn of level entities
-            _ => ()
+            _ => (),
         };
-     }
-
+    }
 }

--- a/src/util/asset_manager.rs
+++ b/src/util/asset_manager.rs
@@ -1,0 +1,171 @@
+use crate::util::ron_asset_loader::RonAssetLoader;
+use bevy::{prelude::*, utils::HashMap};
+use serde::de::DeserializeOwned;
+use std::marker::PhantomData;
+
+/// Plugin to manage assets of type T.
+///
+/// ### Loading
+/// The asset type shall be registered with the [App].
+/// Assets can be loaded from `.ron` files or any format with bevy built in support.
+///
+/// ### Management
+/// Management is optional.
+/// Entities to be managed require the [AssetHandle] component.
+///
+/// The plugin shall monitor which entities use each asset within [EntityAssetRegistry].
+/// An [EntityAssetReadyEvent] will be sent when the asset is loaded or updated.
+/// This is designed to alert the entity that the asset it uses has been changed and is now ready for us.
+#[derive(Debug, Default)]
+pub struct AssetManagerPlugin<T>(PhantomData<T>);
+
+impl<T: Asset + Default + DeserializeOwned> Plugin for AssetManagerPlugin<T> {
+    fn build(&self, app: &mut App) {
+        app.init_asset::<T>();
+        app.init_asset_loader::<RonAssetLoader<T>>();
+        app.init_resource::<EntityAssetRegistry<T>>();
+        app.add_event::<EntityAssetReadyEvent<T>>();
+        app.add_systems(
+            FixedUpdate,
+            (
+                update_entity_asset_registry_sys::<T>,
+                remove_removed_entities_from_registry::<T>,
+                send_asset_ready_event_sys::<T>,
+                send_asset_ready_when_changed::<T>,
+            ),
+        );
+    }
+}
+
+/// Holds an asset handle related to the containing entity.
+#[derive(Debug, Component)]
+pub struct AssetHandle<T: Asset>(pub Handle<T>);
+
+/// Resource to keep track of any entities associated with each asset.
+///
+/// An [Entity] is associated with an [Asset] through the [AssetHandle] component.
+/// When this component is changed, [update_entity_asset_registry_sys] updates the registry
+/// with a mapping between the entity and the asset it references.
+///
+/// This is helpful for managing entities that depend on an asset.
+#[derive(Debug, Default, Resource)]
+pub struct EntityAssetRegistry<T: bevy::prelude::Asset> {
+    pub handle_entities: HashMap<AssetId<T>, Vec<Entity>>,
+    entity_handles: HashMap<Entity, AssetId<T>>,
+}
+
+/// Updates the list of entities associated with each [AssetId] whenever an entities [AssetHandle] component is changed/added.
+///
+/// Also updated a private reverse lookup for each entities current [AssetId].
+fn update_entity_asset_registry_sys<T: Asset>(
+    mut registry: ResMut<EntityAssetRegistry<T>>,
+    changed_handle_entities: Query<(Entity, &AssetHandle<T>), Changed<AssetHandle<T>>>,
+) {
+    for (entity, handle) in changed_handle_entities.iter() {
+        // try to avoid leaking memory when assets are held in perpetuity.
+        // remove the entity containing the BirdAssetHandle when the handle is updated (i.e. references a new asset).
+        //
+        // once the handle is not used by any entities it can be removed from the registry altogether.
+        // this will decrease the asset ref count and (assuming it is not used elsewhere) allow bevy to clear it from memory.
+        if let Some(entity_asset_id) = registry.entity_handles.get(&entity) {
+            let entity_handle = entity_asset_id.clone(); // do not increase the ref count for this!
+            if let Some(handle_entities) = registry.handle_entities.get_mut(&entity_handle) {
+                if let Some(i) = handle_entities.iter().position(|e| *e == entity) {
+                    handle_entities.remove(i);
+
+                    if handle_entities.is_empty() {
+                        registry.handle_entities.remove(&entity_handle);
+                    }
+                }
+            }
+        }
+
+        // insert the entity as a user of the new reference and add the reverse entity lookup
+        registry
+            .handle_entities
+            .entry(handle.0.id())
+            .or_default()
+            .push(entity);
+        registry.entity_handles.insert(entity, handle.0.id());
+    }
+}
+
+#[derive(Debug, Event)]
+pub struct EntityAssetReadyEvent<T: Asset>(pub (Vec<Entity>, AssetId<T>));
+
+/// Keeps track of entities with changed [AssetHandle] components and sends an [EntityAssetReadyEvent]
+/// once the asset the handle points to is ready.
+///
+/// This could be immediately, in the case of assets already loaded by the [AssetServer],
+/// or some time later if it needs to be brought into memory first.
+fn send_asset_ready_event_sys<T: Asset>(
+    mut asset_ready_evtw: EventWriter<EntityAssetReadyEvent<T>>,
+    mut waiting_entities: Local<HashMap<AssetId<T>, Vec<Entity>>>,
+    new_entities: Query<(Entity, &AssetHandle<T>), Changed<AssetHandle<T>>>,
+    assets: Res<Assets<T>>,
+) {
+    for (entity, handle) in new_entities.iter() {
+        waiting_entities
+            .entry(handle.0.id())
+            .or_default()
+            .push(entity);
+    }
+
+    let mut empty_entries = vec![];
+    for (asset_id, entities) in waiting_entities.iter() {
+        if assets.get(*asset_id).is_some() {
+            asset_ready_evtw.send(EntityAssetReadyEvent((entities.clone(), *asset_id)));
+            empty_entries.push(asset_id.clone())
+        }
+    }
+
+    for entry in empty_entries {
+        waiting_entities.remove(&entry);
+    }
+}
+
+/// Sends an [EntityAssetReadyEvent] event when an entity is modified.
+/// Allows entities that depend on assets to be rebuilt/updated when the asset is updated.
+///
+/// TODO When bevy cargo feature `file_watcher` is disabled, this should have no effect and could be disabled.
+fn send_asset_ready_when_changed<T: Asset>(
+    mut asset_events: EventReader<AssetEvent<T>>,
+    mut asset_ready_evtw: EventWriter<EntityAssetReadyEvent<T>>,
+    registry: Res<EntityAssetRegistry<T>>,
+) {
+    for event in asset_events.read() {
+        match event {
+            AssetEvent::Modified { id } => {
+                let entities = registry
+                    .handle_entities
+                    .get(id)
+                    .cloned()
+                    .unwrap_or_default();
+                asset_ready_evtw.send(EntityAssetReadyEvent((entities, *id)));
+            }
+            _ => (),
+        }
+    }
+}
+
+/// Removes [Entity] from the [EntityAssetRegistry] when either:
+/// - An entity with a [AssetHandle] component is removed from the world
+/// - The [AssetHandle] is removed from an entity
+///
+/// Keeping removed entities in the registry can cause panics in code that
+/// expects the entities to exist, so clearing them out is important.
+fn remove_removed_entities_from_registry<T: Asset>(
+    mut registry: ResMut<EntityAssetRegistry<T>>,
+    mut removed: RemovedComponents<AssetHandle<T>>,
+) {
+    for entity in removed.read() {
+        if let Some(&asset_id) = registry.entity_handles.get(&entity) {
+            if let Some(eh) = registry.handle_entities.get_mut(&asset_id) {
+                let index = eh.iter().position(|e| *e == entity);
+                if let Some(index) = index {
+                    eh.remove(index);
+                }
+            }
+        }
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,1 +1,4 @@
 pub mod ron_asset_loader;
+pub mod asset_manager;
+
+pub use asset_manager::{ AssetHandle, EntityAssetReadyEvent, AssetManagerPlugin };


### PR DESCRIPTION
there are many types of entity in the game that should read at least some of their configuration from an external asset. currently this includes birds, but may extend to other entities such players, food, power-ups etc.

this generalises the systems required to denote an asset as being related to an entity, to load it from a `.ron` (or other built in type) on the file system, and to allow entity specific subsystems to hook into this load/reload cycle with minimum fuss.